### PR TITLE
Add spec for having operational discussions as github issues

### DIFF
--- a/specs/ops-matters-discussions.md
+++ b/specs/ops-matters-discussions.md
@@ -1,0 +1,56 @@
+# Use Github Issues on this repository (CCI-MOC/ops-docs) for ops discussions
+
+We need a place to have discussion about our operational policy.
+The idea is to create issues on github and discuss the policy there.
+
+## Problem Description
+
+It is not ideal to discuss operational matters in group chats because:
+
+* it's not easier to add more people to the discussion
+* messages get lost in long chat threads.
+* chats are not async enough.
+
+## Policy
+
+Users will create issues on this repository to discuss operational matters.
+People can then comment on the github issues, or respond via email to take
+part in those discussions.
+
+An issue can be assigned to someone or multiple people, it can also be linked
+from a trello card.
+
+Memebers of the #coredev channels should be encouraged to watch this repository
+so they'll get email notifications when a new issue is opened or when there's
+any discussion.
+
+## Alternatives & History
+
+An alternative would be to setup an `ops-chat` mailing list proposed here:
+
+https://github.com/larsks/ops-policy/commit/486a30e9ca8f1e18e5c24f19e4342c89d656a501
+
+We already have mailman, so it's pretty easy to create a mailing list.
+I am not sure how we will archive the mailing lists though.
+
+## Implementation
+
+### Author(s)
+
+Primary author: <naved001@bu.edu>
+
+### Milestones
+
+We can start having our operational discussions if this is merged.
+
+### Work Items
+
+None
+
+## References
+
+## License
+
+This work is licensed under a Creative Commons Attribution 3.0
+Unported License.
+<http://creativecommons.org/licenses/by/3.0/legalcode>


### PR DESCRIPTION
To be honest, I don't feel too strongly about it. I am writing this because
@larsks encouraged me to do so.