### PR TITLE
Converting size to estimate for zenhub

### DIFF
--- a/policies/0006-label-taxonomy.md
+++ b/policies/0006-label-taxonomy.md
@@ -84,19 +84,13 @@ with the following axes that cover most of our existing labels:
   - `priority/high`
   - `priority/critical`
 
-- **Size**
+- **Epic**
 
-  The `size` axis is used to guage size of issues. Further details can be
-  found [here][Sizing].
+  This label is used to denote that there is an epic with the same name. These
+  issues also tracks the discussions around architectural decisions for the
+  Epic.
 
-  - `size/extra small`
-  - `size/small`
-  - `size/medium`
-  - `size/large`
-  - `size/extra large`
-  - `size/milestone`
-
-[Sizing]: https://github.com/CCI-MOC/ops-docs/blob/master/practices/0004-github-issues-sizing.md
+  - `epic`
 
 ## Alternatives & History
 
@@ -107,10 +101,12 @@ None
 ### Author(s)
 
 Primary author:
-  - Lars Kellogg-Stedman <lars@redhat.com>
+
+- Lars Kellogg-Stedman <lars@redhat.com>
 
 Other contributors:
-  - Joachim Weyl <joachimw@bu.edu>
+
+- Joachim Weyl <joachimw@bu.edu>
 
 ### Milestones
 
@@ -127,7 +123,6 @@ the ops team.
 Several people have written about label taxonomies specifically in the
 context of GitHub:
 
-
 - [Sane Github
   Labels](https://medium.com/@dave_lunny/sane-github-labels-c5d2e6004b63),
   by Dave Lunny
@@ -137,7 +132,6 @@ context of GitHub:
 - [How we organize GitHub issues: A simple styleguide for
   tagging](https://robinpowered.com/blog/best-practice-system-for-organizing-and-tagging-github-issues),
   by the folks at Robin
-
 
 ## License
 

--- a/practices/0004-github-issues-sizing.md
+++ b/practices/0004-github-issues-sizing.md
@@ -3,29 +3,33 @@
 It is important to keep in mind that each time a new team member joins the
 team we will need to reiterate the size definitions. We will also need to
 reevaluate the team understanding of size to include the ideas and
-understandings of the new team members.
+understandings of the new team members. This version now includes our use
+of ZenHub estimates.
 
-## Size
+## Size/Estimate
 
-1. Extra Small - Most requirements are understood, relatively easy, likely
+1. 1 - Most requirements are understood, relatively easy, likely
 completed in a day or less.
 
-1. Small - A little bit of thought and effort required, similar work has been
+1. 2 - A little bit of thought and effort required, similar work has been
 done before, or it is extra small but there is a small unknown.
 
-1. Medium - Similar work has been done before, it is clear what needs to be
+1. 3 - Some thought and effort required, similar work has been done before,
+or it is extra small but there is a medium unknown.
+
+1. 5 - Similar work has been done before, it is clear what needs to be
 done, a few extra steps beyond a small.
 
-1. Large - Similar work has not been done recently, this is complex, will
+1. 8 - Similar work has not been done recently, this is complex, will
 often require assistance from other team members, commonly the largest size
 done in a sprint.
 
-1. Extra Large - Similar work has not been done before, might require
+1. 13 - Similar work has not been done before, might require
 research, this is going to take a lot of time, there is considerable risks
 that could block this from finishing in one sprint, will require extra team
 members to work on it.
 
-1. Epic/Milestone - this needs to be broken down into multiple issues.
+1. epic - this needs to be broken down into multiple issues.
 
 ## Process
 
@@ -39,21 +43,21 @@ definitions above as a second guide.
 
     1. With Scrum Master throwing out defining questions and or suggestions.
 
-1. If Issues are too large and need to be in the sprint they are broken down
+1. If issues are too large and need to be in the sprint they are broken down
 prior to end of sprint planning.
 
     1. Often done in backlog grooming prior to a sprint.
 
 ## Use
 
-1. The first Sprint we will just be adding sizes to all of our issues for
-that sprint.
+1. The first Sprint we will just be adding sizes/estimates to all of our
+issues for that sprint.
 
 1. The second Sprint this will include the above and calculating how many of
-each size we fit into the previous sprint.
+each size/estimate we fit into the previous sprint.
 
 1. The third Sprint we will do all the above and calculate how many of each
-size is in the next sprint.
+size/estimate is in the next sprint.
 
 1. The Fourth Sprint we will do all the above and use the calculation to reject
 some issues that are drastically larger than previous sprints or add more if


### PR DESCRIPTION
We started using ZenHub which has estimates instead of size. We will be using estimates in ZenHub and therefore taxonomy and size information neded to be updated. Some small markdown edits as well.

closes CCI-MOC/ops-docs#23