### PR TITLE
Policy Proposal: Require DCO for Contributions

### DIFF
--- a/policies/0011-dco.md
+++ b/policies/0011-dco.md
@@ -1,0 +1,116 @@
+# Requirement for Developer Certificate of Origin
+
+This policy proposes the implementation of a Developer Certificate of Origin (DCO) requirement for contributions to repositories within the `CCI-MOC`, `nerc-project`, and `OCP-on-NERC` GitHub organizations.
+
+## Problem Description
+
+Open source projects require a clear record of the provenance of contributions to ensure that all code and documentation are legally contributed and can be licensed under the project's chosen open source license.
+Without a formal process, the organization may face legal risks regarding intellectual property rights.
+
+While Contributor License Agreements (CLAs) are one way to handle this, they are often seen as heavyweight and can discourage contributions.
+The Developer Certificate of Origin (DCO) is a lightweight alternative used by projects like the Linux Kernel and the CNCF to certify that the contributor has the right to submit the work.
+
+## Policy
+
+All commits to repositories under the `CCI-MOC`, `nerc-project`, and `OCP-on-NERC` organizations must be "signed off."
+This sign-off indicates that the contributor agrees to the terms of the Developer Certificate of Origin (version 1.1).
+
+> Developer's Certificate of Origin 1.1
+>
+> By making a contribution to this project, I certify that:
+>
+> (a) The contribution was created in whole or in part by me and I
+>     have the right to submit it under the open source license
+>     indicated in the file; or
+>
+> (b) The contribution is based upon previous work that, to the best
+>     of my knowledge, is covered under an appropriate open source
+>     license and I have the right under that license to submit that
+>     work with modifications, whether created in whole or in part
+>     by me, under the same open source license (unless I am
+>     permitted to submit under a different license), as indicated
+>     in the file; or
+>
+> (c) The contribution was provided directly to me by some other
+>     person who certified (a), (b) or (c) and I have not modified
+>     it.
+>
+> (d) I understand and agree that this project and the contribution
+>     are public and that a record of the contribution (including all
+>     personal information I submit with it, including my sign-off) is
+>     maintained indefinitely and may be redistributed consistent with
+>     this project or the open source license(s) involved.
+
+
+### How to Sign Off Your Commits
+
+Signing off a commit is a simple process integrated into the standard Git workflow.
+
+When making a new commit, use the `-s` or `--signoff` flag:
+
+```bash
+git commit -s -m "Your commit message"
+```
+
+This automatically appends a line like this to the end of your commit message:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The `-s` flag also integrates with the `--amend` flag for existing commits:
+
+```bash
+git commit --amend --no-edit -s
+```
+
+If you have a series of commits that need sign-offs before pushing a PR:
+
+```bash
+git rebase --signoff HEAD~N  # N the number of commits to sign
+```
+
+
+As signing off a commit is expected to be a conscious act, there is no supported way of automatically turning it on for all commits.
+However, you can configure a Git alias as shorthand:
+
+```bash
+git config --global alias.cs 'commit -s'
+git cs -m "Your message"
+```
+
+## Alternatives
+
+* **Contributor License Agreement (CLA):** Too legally burdensome for many individual contributors.
+* **No Policy:** Leaves the organization vulnerable to "drive-by" contributions where the legal right to distribute the code might be unclear.
+
+## Implementation
+
+### Author(s)
+
+Primary author:
+
+- knikolla
+
+### Milestones
+
+1. 2026-05-13 - Policy Proposal
+2. 2026-05-13 - Activation of the `cncf/dco2` GitHub App on select repositories of the `CCI-MOC` organization.
+3. 2026-06-13 - Activation of the `cncf/dco2` GitHub App on select repositories of the `nerc-project` and `OCP-on-NERC` organizations.
+4. 2026-07-13 - Full enforcement begins; all new PRs to all repositories across the organizations must pass the DCO check.
+
+### Work Items
+
+- Install the [CNCF DCO2 GitHub App](https://github.com/apps/dco-2) for both organizations.
+- Update CONTRIBUTING.md in core repositories to include sign-off instructions.
+
+## References
+
+- [Official DCO Text (developercertificate.org)](https://developercertificate.org/)
+- [CNCF DCO2 App](https://github.com/apps/dco-2)
+
+## License
+
+This work is licensed under a Creative Commons Attribution 3.0 Unported License.
+
+[http://creativecommons.org/licenses/by/3.0/legalcode](http://creativecommons.org/licenses/by/3.0/legalcode)


### PR DESCRIPTION
This policy proposes the implementation of a Developer Certificate of Origin (DCO) requirement for contributions to repositories within the `CCI-MOC`, `nerc-project`, and `OCP-on-NERC` GitHub organizations.

Closes https://github.com/CCI-MOC/ops-issues/issues/657
Closes https://github.com/CCI-MOC/ops-issues/issues/658